### PR TITLE
Adding else path to createOrUpdate method on base service.

### DIFF
--- a/rf-service/rf-service-base.js
+++ b/rf-service/rf-service-base.js
@@ -1191,6 +1191,8 @@ export class ServiceBase {
       } else {
         throw new QueryError('No criteria for find the row.');
       }
+    } else {
+      updateData = {...data};
     }
 
     let row = await this.getSingle({ ...options, skipNoRowsError: true });


### PR DESCRIPTION
Else path of createOrUpdate was missing and updateData never got set, thereby never creating or updating in the cases where createOrUpdate is called with a where option.