### PR TITLE
#397: Add GUI for images (resources) upload

### DIFF
--- a/rh-page/conf_data.js
+++ b/rh-page/conf_data.js
@@ -12,4 +12,17 @@ export const data = {
     { name: 'image/png',     title: loc._cf('resourceType', 'PNG image'), isTranslatable: true, ownerModule: name },
     { name: 'image/svg+xml', title: loc._cf('resourceType', 'SVG image'), isTranslatable: true, ownerModule: name },
   ],
+
+  roles: [
+    { name: 'resourceManager', title: loc._cf('role', 'Resource manager'), isTranslatable: true, ownerModule: name },
+  ],
+
+  rolesParentsSites: [
+    { role: 'admin', parent: 'resourceManager', site: 'system', ownerModule: name },
+  ],
+
+  permissions: [
+    { name: 'resource.get',    title: loc._cf('permission', 'Get resources'),    isTranslatable: true, roles: 'resourceManager', ownerModule: name, menuItem: { label: loc._cf('menu', 'Resources'), isTranslatable: true, icon: 'resource', action: 'grid', service: 'resource' }},
+    { name: 'resource.create', title: loc._cf('permission', 'Create resources'), isTranslatable: true, roles: 'resourceManager', ownerModule: name, },
+  ]
 };

--- a/rh-page/controllers/resource.js
+++ b/rh-page/controllers/resource.js
@@ -112,7 +112,7 @@ export class ResourceController extends Controller {
     }
   }
 
-  posPermission = 'resource.create';
+  postPermission = 'resource.create';
   postMiddleware = upload;
   async post(req, res) {
     checkParameter(

--- a/rh-page/routes/resource.js
+++ b/rh-page/routes/resource.js
@@ -1,8 +1,0 @@
-import { ResourceController } from '../controllers/resource.js';
-import { corsSimplePreflight, asyncHandler, methodNotAllowed } from 'http-util';
-
-export default (app) => {
-  app.options('/resource', corsSimplePreflight('GET'));
-  app.get('/resource/:name', asyncHandler(ResourceController, 'get'));
-  app.all('/resource', methodNotAllowed);
-};

--- a/rh-page/services/resource.js
+++ b/rh-page/services/resource.js
@@ -10,7 +10,7 @@ export class ResourceService extends Service.IdUuidEnableNameTranslatable {
     },
     language: true,
   };
-  viewAttributes = ['uuid', 'name', 'title', 'content'];
+  viewAttributes = ['uuid', 'name', 'title'];
   
   init() {
     super.init();


### PR DESCRIPTION
Changed resource controller to extend controller and no longer depend on manually configured routes. Changed previously defined get endpoint to get /:name. Added getData endpoint to controller (used for grid). Added post endpoint to controller for resource upload. Added getInterface to controller.